### PR TITLE
Add login page for API auth

### DIFF
--- a/pedidos-churros-cuchito-we/src/app/login/page.tsx
+++ b/pedidos-churros-cuchito-we/src/app/login/page.tsx
@@ -1,0 +1,61 @@
+'use client'
+import { useState } from 'react'
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [result, setResult] = useState<any>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setError(null)
+    setResult(null)
+    try {
+      const res = await fetch('http://localhost:3000/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      })
+      if (!res.ok) {
+        const text = await res.text()
+        throw new Error(text || 'Request failed')
+      }
+      const data = await res.json()
+      setResult(data)
+    } catch (err: any) {
+      setError(err.message)
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen p-4 gap-4">
+      <h1 className="text-2xl font-bold mb-4">Login</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2 w-80">
+        <input
+          type="email"
+          className="border p-2"
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          className="border p-2"
+          placeholder="Password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          required
+        />
+        <button type="submit" className="bg-black text-white py-2">Login</button>
+      </form>
+      {error && <p className="text-red-500">{error}</p>}
+      {result && (
+        <pre className="bg-gray-100 p-2 text-left whitespace-pre-wrap w-80 overflow-x-auto">
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      )}
+    </div>
+  )
+}

--- a/pedidos-churros-cuchito-we/src/app/page.tsx
+++ b/pedidos-churros-cuchito-we/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 
 export default function Home() {
   return (
@@ -49,6 +50,12 @@ export default function Home() {
           >
             Read our docs
           </a>
+          <Link
+            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto"
+            href="/login"
+          >
+            Login
+          </Link>
         </div>
       </main>
       <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">


### PR DESCRIPTION
## Summary
- create a `/login` page with a form that posts to the API
- add link to the new login page on the home screen

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864799a1480832f8b1e554853e9beeb