### PR TITLE
Add token refresh logic

### DIFF
--- a/pedidos-churros-cuchito-we/src/app/login/page.tsx
+++ b/pedidos-churros-cuchito-we/src/app/login/page.tsx
@@ -88,8 +88,10 @@ export default function LoginPage() {
       const data = await res.json()
       setResult(data)
       const token = data?.token || data?.access_token || data?.accessToken
+      const refresh = data?.refreshToken || data?.refresh_token
+      if (token) localStorage.setItem('token', token)
+      if (refresh) localStorage.setItem('refreshToken', refresh)
       if (token) {
-        localStorage.setItem('token', token)
         router.push('/products')
       }
     } catch (err: any) {

--- a/pedidos-churros-cuchito-we/src/app/products/page.tsx
+++ b/pedidos-churros-cuchito-we/src/app/products/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { HiPlus } from 'react-icons/hi'
+import { fetchWithAuth } from '@/utils/api'
 
 interface Product {
   id: string
@@ -34,9 +35,8 @@ export default function ProductsPage() {
       router.replace('/login')
       return
     }
-    fetch('http://localhost:3000/api/products', {
-      headers: { Authorization: `Bearer ${token}` },
-    })
+
+    fetchWithAuth('http://localhost:3000/api/products')
       .then(async (res) => {
         if (!res.ok) {
           const text = await res.text()

--- a/pedidos-churros-cuchito-we/src/utils/api.ts
+++ b/pedidos-churros-cuchito-we/src/utils/api.ts
@@ -1,0 +1,63 @@
+export async function fetchWithAuth(
+  input: RequestInfo | URL,
+  init: RequestInit = {}
+): Promise<Response> {
+  let token = localStorage.getItem('token');
+  const refreshToken = localStorage.getItem('refreshToken');
+
+  const headers = new Headers(init.headers || {});
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  let response = await fetch(input, { ...init, headers });
+
+  if (response.status === 403) {
+    const message = await response.text();
+
+    if (message.includes('Token inválido o expirado') && refreshToken) {
+      const refreshRes = await fetch('http://localhost:3000/api/auth/refresh', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refreshToken }),
+      });
+
+      if (refreshRes.ok) {
+        const data = await refreshRes.json();
+        const newToken = data.token || data.access_token || data.accessToken;
+        const newRefresh = data.refreshToken || data.refresh_token;
+        if (newToken) {
+          localStorage.setItem('token', newToken);
+          token = newToken;
+        }
+        if (newRefresh) {
+          localStorage.setItem('refreshToken', newRefresh);
+        }
+        headers.set('Authorization', `Bearer ${token}`);
+        response = await fetch(input, { ...init, headers });
+      } else if (refreshRes.status === 403) {
+        const refreshMsg = await refreshRes.text();
+        if (refreshMsg.includes('Refresh token inválido o expirado')) {
+          localStorage.removeItem('token');
+          localStorage.removeItem('refreshToken');
+          window.location.href = '/login';
+          throw new Error(refreshMsg);
+        } else {
+          throw new Error(refreshMsg || 'Request failed');
+        }
+      } else {
+        const refreshMsg = await refreshRes.text();
+        throw new Error(refreshMsg || 'Request failed');
+      }
+    } else if (message.includes('Refresh token inválido o expirado')) {
+      localStorage.removeItem('token');
+      localStorage.removeItem('refreshToken');
+      window.location.href = '/login';
+      throw new Error(message);
+    } else {
+      throw new Error(message || 'Request failed');
+    }
+  }
+
+  return response;
+}


### PR DESCRIPTION
## Summary
- store refresh token on login
- add `fetchWithAuth` helper to automatically refresh expired tokens
- use helper when loading products

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68672d0c86c4832f80f4c7b56327f63e