### PR TITLE
Implement basic shopping cart

### DIFF
--- a/pedidos-churros-cuchito-we/src/app/cart/page.tsx
+++ b/pedidos-churros-cuchito-we/src/app/cart/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useCart } from '../../context/CartContext'
+import { HiTrash } from 'react-icons/hi'
 
 export default function CartPage() {
   const { items, removeItem, clearCart } = useCart()
@@ -14,28 +15,52 @@ export default function CartPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 to-yellow-100 p-4">
-      <h1 className="text-2xl font-bold mb-4">Carrito de compras</h1>
-      <ul className="space-y-4">
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 to-yellow-100 py-8 px-2 sm:px-6">
+      <h1 className="text-4xl font-extrabold mb-8 text-black text-center">Carrito de compras</h1>
+      
+      <ul className="space-y-6 max-w-3xl mx-auto">
         {items.map((item) => (
-          <li key={item.id} className="flex items-center justify-between bg-white p-4 rounded shadow">
-            <div className="flex items-center gap-4">
-              {item.image_url && <img src={item.image_url} alt={item.name} className="w-16 h-16 object-cover rounded" />}
-              <div>
-                <p className="font-semibold">{item.name}</p>
-                <p className="text-sm text-gray-600">Cantidad: {item.quantity}</p>
+          <li
+            key={item.id}
+            className="flex flex-col sm:flex-row items-center justify-between bg-white/90 border border-orange-100 rounded-2xl shadow-md px-4 py-4 gap-3"
+          >
+            <div className="flex items-center gap-5 w-full sm:w-auto">
+              {item.image_url && (
+                <img
+                  src={item.image_url}
+                  alt={item.name}
+                  className="w-20 h-20 object-cover rounded-lg border border-orange-50 shadow"
+                />
+              )}
+              <div className="flex flex-col">
+                <span className="font-bold text-lg text-gray-900">{item.name}</span>
+                <span className="text-gray-500 text-sm mt-1">Cantidad: <span className="font-semibold">{item.quantity}</span></span>
               </div>
             </div>
-            <div className="text-right">
-              <p className="font-semibold">${(item.price * item.quantity).toLocaleString('es-CL')}</p>
-              <button onClick={() => removeItem(item.id)} className="text-sm text-red-500 hover:underline">Quitar</button>
+            <div className="flex flex-col items-end gap-2 w-full sm:w-auto mt-3 sm:mt-0">
+              <span className="font-bold text-xl text-gray-800">${(item.price * item.quantity).toLocaleString('es-CL')}</span>
+              <button
+                onClick={() => removeItem(item.id)}
+                className="flex items-center gap-1 px-3 py-1 rounded-lg text-sm bg-orange-50 text-orange-600 font-bold hover:bg-orange-100 border border-orange-200 transition"
+              >
+                <HiTrash className="text-orange-500" />
+                Quitar
+              </button>
             </div>
           </li>
         ))}
       </ul>
-      <div className="mt-6 flex justify-between items-center">
-        <button onClick={clearCart} className="text-sm text-red-600 hover:underline">Vaciar carrito</button>
-        <p className="text-xl font-bold">Total: ${total.toLocaleString('es-CL')}</p>
+
+      <div className="max-w-3xl mx-auto flex flex-col-reverse sm:flex-row justify-between items-center gap-4 mt-10 bg-white/90 border border-orange-100 rounded-2xl shadow px-6 py-5">
+        <button
+          onClick={clearCart}
+          className="text-base font-semibold text-orange-600 hover:text-white hover:bg-orange-500 px-4 py-2 rounded-lg border border-orange-200 transition"
+        >
+          Vaciar carrito
+        </button>
+        <span className="text-2xl font-extrabold text-gray-900">
+          Total: ${total.toLocaleString('es-CL')}
+        </span>
       </div>
     </div>
   )

--- a/pedidos-churros-cuchito-we/src/app/cart/page.tsx
+++ b/pedidos-churros-cuchito-we/src/app/cart/page.tsx
@@ -1,0 +1,42 @@
+'use client'
+import { useCart } from '../../context/CartContext'
+
+export default function CartPage() {
+  const { items, removeItem, clearCart } = useCart()
+  const total = items.reduce((acc, i) => acc + i.price * i.quantity, 0)
+
+  if (!items.length) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen bg-gradient-to-br from-orange-50 to-yellow-100">
+        <p className="text-lg text-gray-700">Tu carrito está vacío.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 to-yellow-100 p-4">
+      <h1 className="text-2xl font-bold mb-4">Carrito de compras</h1>
+      <ul className="space-y-4">
+        {items.map((item) => (
+          <li key={item.id} className="flex items-center justify-between bg-white p-4 rounded shadow">
+            <div className="flex items-center gap-4">
+              {item.image_url && <img src={item.image_url} alt={item.name} className="w-16 h-16 object-cover rounded" />}
+              <div>
+                <p className="font-semibold">{item.name}</p>
+                <p className="text-sm text-gray-600">Cantidad: {item.quantity}</p>
+              </div>
+            </div>
+            <div className="text-right">
+              <p className="font-semibold">${(item.price * item.quantity).toLocaleString('es-CL')}</p>
+              <button onClick={() => removeItem(item.id)} className="text-sm text-red-500 hover:underline">Quitar</button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <div className="mt-6 flex justify-between items-center">
+        <button onClick={clearCart} className="text-sm text-red-600 hover:underline">Vaciar carrito</button>
+        <p className="text-xl font-bold">Total: ${total.toLocaleString('es-CL')}</p>
+      </div>
+    </div>
+  )
+}

--- a/pedidos-churros-cuchito-we/src/app/components/TopBar.tsx
+++ b/pedidos-churros-cuchito-we/src/app/components/TopBar.tsx
@@ -1,7 +1,8 @@
 'use client'
 import { useState, useEffect, useRef } from 'react'
-import { HiMenu, HiOutlineUserCircle, HiX } from 'react-icons/hi'
+import { HiMenu, HiOutlineUserCircle, HiX, HiShoppingCart } from 'react-icons/hi'
 import logoBanner from '../assert/logo-banner.png'
+import { useCart } from '../../context/CartContext'
 
 const MENU_LINKS = [
   { href: '/perfil', label: 'Perfil' },
@@ -13,6 +14,7 @@ const MENU_LINKS = [
 export default function TopBar() {
   const [open, setOpen] = useState(false)
   const drawerRef = useRef<HTMLDivElement>(null)
+  const { items } = useCart()
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -48,6 +50,14 @@ export default function TopBar() {
             ))}
           </div>
           <div className="flex items-center gap-4">
+            <a href="/cart" className="relative text-gray-700 hover:text-orange-500 transition" aria-label="Carrito">
+              <HiShoppingCart size={24} />
+              {items.length > 0 && (
+                <span className="absolute -top-2 -right-2 bg-orange-500 text-white text-xs rounded-full px-1">
+                  {items.reduce((acc, i) => acc + i.quantity, 0)}
+                </span>
+              )}
+            </a>
             <button className="text-gray-700 hover:text-orange-500 transition" aria-label="Usuario">
               <HiOutlineUserCircle size={26} />
             </button>

--- a/pedidos-churros-cuchito-we/src/app/components/TopBar.tsx
+++ b/pedidos-churros-cuchito-we/src/app/components/TopBar.tsx
@@ -5,6 +5,7 @@ import logoBanner from '../assert/logo-banner.png'
 import { useCart } from '../../context/CartContext'
 
 const MENU_LINKS = [
+  { href: '/products', label: 'Productos' },
   { href: '/perfil', label: 'Perfil' },
   { href: '/mis-pedidos', label: 'Mis pedidos' },
   { href: '/admin', label: 'Administración' },

--- a/pedidos-churros-cuchito-we/src/app/layout.tsx
+++ b/pedidos-churros-cuchito-we/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import TopBar from "./components/TopBar";
+import { CartProvider } from "../context/CartContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,8 +29,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <TopBar />
-        {children}
+        <CartProvider>
+          <TopBar />
+          {children}
+        </CartProvider>
       </body>
     </html>
   );

--- a/pedidos-churros-cuchito-we/src/app/products/page.tsx
+++ b/pedidos-churros-cuchito-we/src/app/products/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { HiPlus } from 'react-icons/hi'
+import { useCart } from '../../context/CartContext'
 import { fetchWithAuth } from '@/utils/api'
 
 interface Product {
@@ -28,6 +29,7 @@ export default function ProductsPage() {
   const [error, setError] = useState<string | null>(null)
   const [activeCategory, setActiveCategory] = useState('churros')
   const router = useRouter()
+  const { addItem } = useCart()
 
   useEffect(() => {
     const token = localStorage.getItem('token')
@@ -122,6 +124,14 @@ export default function ProductsPage() {
                     className="ml-2 bg-orange-500 hover:bg-orange-600 text-white rounded-full p-2 shadow transition"
                     aria-label={`Agregar ${p.name} al carrito`}
                     tabIndex={0}
+                    onClick={() =>
+                      addItem({
+                        id: p.id,
+                        name: p.name,
+                        price: parseInt(p.price),
+                        image_url: p.image_url,
+                      })
+                    }
                   >
                     <HiPlus size={22} />
                   </button>

--- a/pedidos-churros-cuchito-we/src/context/CartContext.tsx
+++ b/pedidos-churros-cuchito-we/src/context/CartContext.tsx
@@ -1,0 +1,66 @@
+'use client'
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+
+export interface CartItem {
+  id: string
+  name: string
+  price: number
+  quantity: number
+  image_url?: string
+}
+
+interface CartContextProps {
+  items: CartItem[]
+  addItem: (item: Omit<CartItem, 'quantity'>) => void
+  removeItem: (id: string) => void
+  clearCart: () => void
+}
+
+const CartContext = createContext<CartContextProps | undefined>(undefined)
+
+export function useCart() {
+  const ctx = useContext(CartContext)
+  if (!ctx) throw new Error('useCart must be used within CartProvider')
+  return ctx
+}
+
+export function CartProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<CartItem[]>([])
+
+  // Load from localStorage
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem('cart')
+      if (stored) setItems(JSON.parse(stored))
+    } catch {}
+  }, [])
+
+  // Persist to localStorage
+  useEffect(() => {
+    localStorage.setItem('cart', JSON.stringify(items))
+  }, [items])
+
+  const addItem = (item: Omit<CartItem, 'quantity'>) => {
+    setItems((prev) => {
+      const existing = prev.find((i) => i.id === item.id)
+      if (existing) {
+        return prev.map((i) =>
+          i.id === item.id ? { ...i, quantity: i.quantity + 1 } : i
+        )
+      }
+      return [...prev, { ...item, quantity: 1 }]
+    })
+  }
+
+  const removeItem = (id: string) => {
+    setItems((prev) => prev.filter((i) => i.id !== id))
+  }
+
+  const clearCart = () => setItems([])
+
+  return (
+    <CartContext.Provider value={{ items, addItem, removeItem, clearCart }}>
+      {children}
+    </CartContext.Provider>
+  )
+}

--- a/pedidos-churros-cuchito-we/src/context/CartContext.tsx
+++ b/pedidos-churros-cuchito-we/src/context/CartContext.tsx
@@ -13,6 +13,8 @@ interface CartContextProps {
   items: CartItem[]
   addItem: (item: Omit<CartItem, 'quantity'>) => void
   removeItem: (id: string) => void
+  removeOne: (id: string) => void              // Nuevo: resta 1 unidad, o elimina si llega a cero
+  getQuantity: (id: string) => number          // Nuevo: retorna la cantidad actual (o 0)
   clearCart: () => void
 }
 
@@ -56,10 +58,33 @@ export function CartProvider({ children }: { children: ReactNode }) {
     setItems((prev) => prev.filter((i) => i.id !== id))
   }
 
+  // Nuevo: resta 1. Si queda en 0, elimina del carrito
+  const removeOne = (id: string) => {
+    setItems((prev) => {
+      const newCart = prev
+        .map((item) =>
+          item.id === id
+            ? { ...item, quantity: Math.max(0, item.quantity - 1) }
+            : item
+        )
+        .filter((item) => item.quantity > 0)
+      console.log('Carrito actualizado:', newCart)
+      return newCart
+    })
+  }
+  
+  
+
+  // Nuevo: devuelve la cantidad actual, o 0
+  const getQuantity = (id: string) => {
+    const item = items.find((i) => i.id === id)
+    return item ? item.quantity : 0
+  }
+
   const clearCart = () => setItems([])
 
   return (
-    <CartContext.Provider value={{ items, addItem, removeItem, clearCart }}>
+    <CartContext.Provider value={{ items, addItem, removeItem, removeOne, getQuantity, clearCart }}>
       {children}
     </CartContext.Provider>
   )


### PR DESCRIPTION
## Summary
- add cart context with add/remove operations
- show cart icon with item count in `TopBar`
- wrap layout with `CartProvider`
- handle adding products to cart
- add `/cart` page to list items

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68674d9d16d8832f925c0d38477bd7f1