### PR TITLE
Add global loading overlay for route transitions

### DIFF
--- a/pedidos-churros-cuchito-we/src/app/components/LoadingOverlay.tsx
+++ b/pedidos-churros-cuchito-we/src/app/components/LoadingOverlay.tsx
@@ -1,12 +1,14 @@
 'use client'
 import { useLoading } from '../../context/LoadingContext'
+import logoBanner from '../assert/logo-banner.png'
 
 export default function LoadingOverlay() {
   const { loading } = useLoading()
   if (!loading) return null
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
-      <div className="w-10 h-10 border-4 border-white border-t-transparent rounded-full animate-spin" />
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-gradient-to-br from-orange-100 to-yellow-50 gap-4">
+      <img src={logoBanner.src} alt="Churros Cuchito Logo" className="h-14 animate-bounce" />
+      <div className="animate-spin rounded-full h-12 w-12 border-4 border-orange-500 border-t-transparent" />
     </div>
   )
 }

--- a/pedidos-churros-cuchito-we/src/app/components/LoadingOverlay.tsx
+++ b/pedidos-churros-cuchito-we/src/app/components/LoadingOverlay.tsx
@@ -1,0 +1,12 @@
+'use client'
+import { useLoading } from '../../context/LoadingContext'
+
+export default function LoadingOverlay() {
+  const { loading } = useLoading()
+  if (!loading) return null
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
+      <div className="w-10 h-10 border-4 border-white border-t-transparent rounded-full animate-spin" />
+    </div>
+  )
+}

--- a/pedidos-churros-cuchito-we/src/app/components/RouteChangeHandler.tsx
+++ b/pedidos-churros-cuchito-we/src/app/components/RouteChangeHandler.tsx
@@ -1,0 +1,16 @@
+'use client'
+import { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
+import { useLoading } from '../../context/LoadingContext'
+
+export default function RouteChangeHandler() {
+  const pathname = usePathname()
+  const { setLoading } = useLoading()
+
+  useEffect(() => {
+    // When the route changes, hide the loader
+    setLoading(false)
+  }, [pathname, setLoading])
+
+  return null
+}

--- a/pedidos-churros-cuchito-we/src/app/components/TopBar.tsx
+++ b/pedidos-churros-cuchito-we/src/app/components/TopBar.tsx
@@ -3,6 +3,8 @@ import { useState, useEffect, useRef } from 'react'
 import { HiMenu, HiOutlineUserCircle, HiX, HiShoppingCart } from 'react-icons/hi'
 import logoBanner from '../assert/logo-banner.png'
 import { useCart } from '../../context/CartContext'
+import Link from 'next/link'
+import { useLoading } from '../../context/LoadingContext'
 
 const MENU_LINKS = [
   { href: '/products', label: 'Productos' },
@@ -16,6 +18,7 @@ export default function TopBar() {
   const [open, setOpen] = useState(false)
   const drawerRef = useRef<HTMLDivElement>(null)
   const { items } = useCart()
+  const { setLoading } = useLoading()
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -40,25 +43,30 @@ export default function TopBar() {
     <>
       <header className="w-full bg-white shadow sticky top-0 z-30">
         <nav className="max-w-7xl mx-auto flex items-center justify-between px-4 py-3">
-          <a href="/" className="flex items-center gap-2">
+          <Link href="/" className="flex items-center gap-2" onClick={() => setLoading(true)}>
             <img src={logoBanner.src} alt="Churros Cuchito Logo" className="h-10" />
-          </a>
+          </Link>
           <div className="hidden md:flex items-center gap-8">
             {MENU_LINKS.map(link => (
-              <a key={link.href} href={link.href} className="font-semibold text-gray-800 hover:text-orange-500 transition">
+              <Link
+                key={link.href}
+                href={link.href}
+                className="font-semibold text-gray-800 hover:text-orange-500 transition"
+                onClick={() => setLoading(true)}
+              >
                 {link.label}
-              </a>
+              </Link>
             ))}
           </div>
           <div className="flex items-center gap-4">
-            <a href="/cart" className="relative text-gray-700 hover:text-orange-500 transition" aria-label="Carrito">
+            <Link href="/cart" className="relative text-gray-700 hover:text-orange-500 transition" aria-label="Carrito" onClick={() => setLoading(true)}>
               <HiShoppingCart size={24} />
               {items.length > 0 && (
                 <span className="absolute -top-2 -right-2 bg-orange-500 text-white text-xs rounded-full px-1">
                   {items.reduce((acc, i) => acc + i.quantity, 0)}
                 </span>
               )}
-            </a>
+            </Link>
             <button className="text-gray-700 hover:text-orange-500 transition" aria-label="Usuario">
               <HiOutlineUserCircle size={26} />
             </button>
@@ -92,14 +100,17 @@ export default function TopBar() {
         </div>
         <nav className="flex flex-col gap-2 mt-6 px-4">
           {MENU_LINKS.map(link => (
-            <a
+            <Link
               key={link.href}
               href={link.href}
               className="block py-2 px-3 rounded-lg font-semibold text-gray-800 hover:bg-orange-50 hover:text-orange-600 transition"
-              onClick={() => setOpen(false)}
+              onClick={() => {
+                setOpen(false)
+                setLoading(true)
+              }}
             >
               {link.label}
-            </a>
+            </Link>
           ))}
         </nav>
         <div className="mt-auto p-4 text-xs text-gray-400">© 2025 Churros Cuchito</div>

--- a/pedidos-churros-cuchito-we/src/app/layout.tsx
+++ b/pedidos-churros-cuchito-we/src/app/layout.tsx
@@ -3,6 +3,9 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import TopBar from "./components/TopBar";
 import { CartProvider } from "../context/CartContext";
+import { LoadingProvider } from "../context/LoadingContext";
+import LoadingOverlay from "./components/LoadingOverlay";
+import RouteChangeHandler from "./components/RouteChangeHandler";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,10 +32,14 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <CartProvider>
-          <TopBar />
-          {children}
-        </CartProvider>
+        <LoadingProvider>
+          <CartProvider>
+            <TopBar />
+            <RouteChangeHandler />
+            <LoadingOverlay />
+            {children}
+          </CartProvider>
+        </LoadingProvider>
       </body>
     </html>
   );

--- a/pedidos-churros-cuchito-we/src/context/LoadingContext.tsx
+++ b/pedidos-churros-cuchito-we/src/context/LoadingContext.tsx
@@ -1,0 +1,25 @@
+'use client'
+import { createContext, useContext, useState, ReactNode } from 'react'
+
+interface LoadingContextProps {
+  loading: boolean
+  setLoading: (value: boolean) => void
+}
+
+const LoadingContext = createContext<LoadingContextProps | undefined>(undefined)
+
+export function useLoading() {
+  const ctx = useContext(LoadingContext)
+  if (!ctx) throw new Error('useLoading must be used within LoadingProvider')
+  return ctx
+}
+
+export function LoadingProvider({ children }: { children: ReactNode }) {
+  const [loading, setLoading] = useState(false)
+
+  return (
+    <LoadingContext.Provider value={{ loading, setLoading }}>
+      {children}
+    </LoadingContext.Provider>
+  )
+}


### PR DESCRIPTION
## Summary
- create `LoadingContext` and provider
- add `LoadingOverlay` component and `RouteChangeHandler`
- integrate loading provider and overlay in root layout
- update `TopBar` links to show loading during navigation

## Testing
- `npm install --silent` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6869dc2edce8832fa1d57cad4f48d9d0