### PR TITLE
Set login as default entry

### DIFF
--- a/pedidos-churros-cuchito-we/src/app/components/OptionalTopBar.tsx
+++ b/pedidos-churros-cuchito-we/src/app/components/OptionalTopBar.tsx
@@ -1,0 +1,9 @@
+'use client'
+import { usePathname } from 'next/navigation'
+import TopBar from './TopBar'
+
+export default function OptionalTopBar() {
+  const pathname = usePathname()
+  if (pathname === '/' || pathname.startsWith('/login')) return null
+  return <TopBar />
+}

--- a/pedidos-churros-cuchito-we/src/app/layout.tsx
+++ b/pedidos-churros-cuchito-we/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import TopBar from "./components/TopBar";
+import OptionalTopBar from "./components/OptionalTopBar";
 import { CartProvider } from "../context/CartContext";
 import { LoadingProvider } from "../context/LoadingContext";
 import LoadingOverlay from "./components/LoadingOverlay";
@@ -34,7 +34,7 @@ export default function RootLayout({
       >
         <LoadingProvider>
           <CartProvider>
-            <TopBar />
+            <OptionalTopBar />
             <RouteChangeHandler />
             <LoadingOverlay />
             {children}

--- a/pedidos-churros-cuchito-we/src/app/login/page.tsx
+++ b/pedidos-churros-cuchito-we/src/app/login/page.tsx
@@ -38,6 +38,13 @@ export default function LoginPage() {
   const router = useRouter()
 
   useEffect(() => {
+    const token = localStorage.getItem('token')
+    if (token) {
+      router.replace('/products')
+    }
+  }, [router])
+
+  useEffect(() => {
     const t = setTimeout(() => setLoading(false), 600)
     return () => clearTimeout(t)
   }, [])

--- a/pedidos-churros-cuchito-we/src/app/page.tsx
+++ b/pedidos-churros-cuchito-we/src/app/page.tsx
@@ -1,110 +1,12 @@
-import Image from "next/image";
-import Link from "next/link";
+'use client'
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 
 export default function Home() {
-  return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-          <Link
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto"
-            href="/login"
-          >
-            Login
-          </Link>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
-  );
+  const router = useRouter()
+  useEffect(() => {
+    const token = localStorage.getItem('token')
+    router.replace(token ? '/products' : '/login')
+  }, [router])
+  return null
 }


### PR DESCRIPTION
## Summary
- add OptionalTopBar client component to hide menu on `/login`
- redirect to `/login` or `/products` from the root page
- auto-redirect from login when already authenticated

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869e4f1a688832f83b845d92b5b497a