### PR TITLE
Implement logout page

### DIFF
--- a/pedidos-churros-cuchito-we/src/app/logout/page.tsx
+++ b/pedidos-churros-cuchito-we/src/app/logout/page.tsx
@@ -1,0 +1,33 @@
+'use client'
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function LogoutPage() {
+  const router = useRouter()
+
+  useEffect(() => {
+    const refreshToken = localStorage.getItem('refreshToken')
+    // Send logout request if refresh token exists
+    if (refreshToken) {
+      fetch('http://localhost:3000/api/auth/logout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refreshToken }),
+      }).finally(() => {
+        localStorage.removeItem('token')
+        localStorage.removeItem('refreshToken')
+        router.replace('/login')
+      })
+    } else {
+      localStorage.removeItem('token')
+      localStorage.removeItem('refreshToken')
+      router.replace('/login')
+    }
+  }, [router])
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-orange-50 to-yellow-100">
+      <span className="text-orange-500 font-bold animate-pulse text-xl">Cerrando sesión...</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add logout page that calls the API and clears local storage

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869f193c1cc832fa35ecdf3041f16be