### PR TITLE
Fix PDF download to use auth token

### DIFF
--- a/pedidos-churros-cuchito-we/src/app/cart/page.tsx
+++ b/pedidos-churros-cuchito-we/src/app/cart/page.tsx
@@ -30,12 +30,10 @@ export default function CartPage() {
 
   // --- Nueva función para descargar ambos PDFs ---
   async function downloadPDFs(orderId: string) {
-    const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null
-  
     // PDF Churros
-    await fetch(`http://localhost:3000/api/orders/${orderId}/pdf?categoria=churros`, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-    })
+    await fetchWithAuth(
+      `http://localhost:3000/api/orders/${orderId}/pdf?categoria=churros`,
+    )
       .then(res => {
         if (res.ok) return res.blob()
         throw new Error('No hay productos de Churros')
@@ -54,9 +52,9 @@ export default function CartPage() {
       }).catch(() => {})
   
     // PDF Otros
-    await fetch(`http://localhost:3000/api/orders/${orderId}/pdf?categoria=otros`, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-    })
+    await fetchWithAuth(
+      `http://localhost:3000/api/orders/${orderId}/pdf?categoria=otros`,
+    )
       .then(res => {
         if (res.ok) return res.blob()
         throw new Error('No hay productos de Otros')


### PR DESCRIPTION
## Summary
- send auth token when downloading order PDFs

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686afc4a76a8832f8768b7ff612870a6