### PR TITLE
feat: add attendance screen

### DIFF
--- a/pedidos-churros-cuchito-we/src/app/asistencias/page.tsx
+++ b/pedidos-churros-cuchito-we/src/app/asistencias/page.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { fetchWithAuth } from '@/utils/api'
+import { getUserIdFromToken, getUserRoleFromToken } from '@/utils/auth'
+import { useLoading } from '../../context/LoadingContext'
+
+interface Asistencia {
+  id: string
+  usuario_id: string
+  fecha: string
+  horario_entrada: string | null
+  horario_salida: string | null
+  horario_inicio_colacion: string | null
+  horario_fin_colacion: string | null
+  created_at: string
+  updated_at: string
+}
+
+type Estado =
+  | 'sin_entrada'
+  | 'en_jornada'
+  | 'en_colacion'
+  | 'colacion_terminada'
+  | 'finalizada'
+
+export default function AsistenciasPage() {
+  const [asistencia, setAsistencia] = useState<Asistencia | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const { setLoading } = useLoading()
+  const router = useRouter()
+
+  useEffect(() => {
+    const role = getUserRoleFromToken()
+    if (role !== 'admin' && role !== 'trabajador' && role !== 'user') {
+      router.replace('/login')
+      return
+    }
+
+    const userId = getUserIdFromToken()
+    if (!userId) {
+      router.replace('/login')
+      return
+    }
+
+    const today = new Date().toISOString().split('T')[0]
+    setLoading(true)
+    fetchWithAuth(`https://tienda-churroscuchito.cl/api/asistencias/${today}/${userId}`)
+      .then(async (res) => {
+        if (res.status === 404) return null
+        if (!res.ok) throw new Error(await res.text())
+        return res.json()
+      })
+      .then((data) => setAsistencia(data))
+      .catch((err) => setError((err as Error).message))
+      .finally(() => setLoading(false))
+  }, [router, setLoading])
+
+  const estado: Estado = (() => {
+    const a = asistencia
+    if (!a || !a.horario_entrada) return 'sin_entrada'
+    if (a.horario_salida) return 'finalizada'
+    if (a.horario_inicio_colacion && !a.horario_fin_colacion) return 'en_colacion'
+    if (a.horario_inicio_colacion && a.horario_fin_colacion && !a.horario_salida)
+      return 'colacion_terminada'
+    return 'en_jornada'
+  })()
+
+  const handleAction = async (tipo: string) => {
+    const userId = getUserIdFromToken()
+    const today = new Date().toISOString().split('T')[0]
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetchWithAuth(
+        `https://tienda-churroscuchito.cl/api/asistencias/usuario/${userId}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tipo, fecha: today }),
+        },
+      )
+      if (!res.ok) throw new Error(await res.text())
+      const data = await res.json()
+      setAsistencia(data)
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 to-yellow-100 py-8 px-4">
+      <div className="max-w-md mx-auto bg-white rounded-2xl shadow p-6 flex flex-col gap-4">
+        <h1 className="text-3xl font-extrabold text-center text-gray-900">Asistencia</h1>
+        <div className="grid gap-2 text-gray-700">
+          <div>
+            Entrada: <b>{asistencia?.horario_entrada ?? '--'}</b>
+          </div>
+          <div>
+            Inicio colación: <b>{asistencia?.horario_inicio_colacion ?? '--'}</b>
+          </div>
+          <div>
+            Fin colación: <b>{asistencia?.horario_fin_colacion ?? '--'}</b>
+          </div>
+          <div>
+            Salida: <b>{asistencia?.horario_salida ?? '--'}</b>
+          </div>
+        </div>
+        {error && <div className="text-red-500 text-sm text-center">{error}</div>}
+        <div className="flex flex-col gap-3 mt-4">
+          {estado === 'sin_entrada' && (
+            <button
+              onClick={() => handleAction('horario_entrada')}
+              className="w-full py-2 bg-orange-500 text-white font-bold rounded-lg hover:bg-orange-600 transition"
+            >
+              Marcar entrada
+            </button>
+          )}
+          {estado === 'en_jornada' && (
+            <>
+              <button
+                onClick={() => handleAction('horario_inicio_colacion')}
+                className="w-full py-2 bg-orange-500 text-white font-bold rounded-lg hover:bg-orange-600 transition"
+              >
+                Iniciar colación
+              </button>
+              <button
+                onClick={() => handleAction('horario_salida')}
+                className="w-full py-2 bg-red-500 text-white font-bold rounded-lg hover:bg-red-600 transition"
+              >
+                Marcar salida
+              </button>
+            </>
+          )}
+          {estado === 'en_colacion' && (
+            <button
+              onClick={() => handleAction('horario_fin_colacion')}
+              className="w-full py-2 bg-orange-500 text-white font-bold rounded-lg hover:bg-orange-600 transition"
+            >
+              Terminar colación
+            </button>
+          )}
+          {estado === 'colacion_terminada' && (
+            <button
+              onClick={() => handleAction('horario_salida')}
+              className="w-full py-2 bg-red-500 text-white font-bold rounded-lg hover:bg-red-600 transition"
+            >
+              Marcar salida
+            </button>
+          )}
+          {estado === 'finalizada' && (
+            <div className="text-center text-gray-600 font-semibold">
+              Asistencia finalizada
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/pedidos-churros-cuchito-we/src/app/asistencias/page.tsx
+++ b/pedidos-churros-cuchito-we/src/app/asistencias/page.tsx
@@ -70,6 +70,17 @@ export default function AsistenciasPage() {
   })()
 
   const handleAction = async (tipo: string) => {
+    if (
+      asistencia &&
+      asistencia.horario_entrada &&
+      asistencia.horario_salida &&
+      asistencia.horario_inicio_colacion &&
+      asistencia.horario_fin_colacion
+    ) {
+      setError('La asistencia ya está completa')
+      return
+    }
+
     const userId = getUserIdFromToken()
     const today = new Date().toISOString().split('T')[0]
     setLoading(true)

--- a/pedidos-churros-cuchito-we/src/app/components/TopBar.tsx
+++ b/pedidos-churros-cuchito-we/src/app/components/TopBar.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect, useRef } from 'react'
 import { usePathname } from 'next/navigation'
-import { HiMenu, HiOutlineUserCircle, HiX, HiShoppingCart } from 'react-icons/hi'
+import { HiMenu, HiX, HiShoppingCart } from 'react-icons/hi'
 import logoBanner from '../assert/logo-banner.png'
 import { useCart } from '../../context/CartContext'
 import Link from 'next/link'
@@ -11,6 +11,7 @@ import { getUserRoleFromToken } from '@/utils/auth' // IMPORTANTE
 // Definimos los links con los roles que pueden verlos
 const MENU_LINKS = [
   { href: '/products', label: 'Productos', roles: ['user', 'admin'] },
+  { href: '/asistencias', label: 'Asistencias', roles: ['user', 'admin'] },
   { href: '/perfil', label: 'Perfil', roles: ['admin'] },
   { href: '/mis-pedidos', label: 'Mis pedidos', roles: ['admin'] },
   { href: '/cierre-caja', label: 'Cierre de caja', roles: ['admin'] },

--- a/pedidos-churros-cuchito-we/src/app/components/TopBar.tsx
+++ b/pedidos-churros-cuchito-we/src/app/components/TopBar.tsx
@@ -10,13 +10,13 @@ import { getUserRoleFromToken } from '@/utils/auth' // IMPORTANTE
 
 // Definimos los links con los roles que pueden verlos
 const MENU_LINKS = [
-  { href: '/products', label: 'Productos', roles: ['user', 'admin'] },
-  { href: '/asistencias', label: 'Asistencias', roles: ['user', 'admin'] },
+  { href: '/products', label: 'Productos', roles: ['user', 'admin', 'trabajador'] },
+  { href: '/asistencias', label: 'Asistencias', roles: ['trabajador', 'admin'] },
   { href: '/perfil', label: 'Perfil', roles: ['admin'] },
   { href: '/mis-pedidos', label: 'Mis pedidos', roles: ['admin'] },
   { href: '/cierre-caja', label: 'Cierre de caja', roles: ['admin'] },
   { href: '/admin', label: 'Administración', roles: ['admin'] },
-  { href: '/logout', label: 'Cerrar sesión', roles: ['user', 'admin'] },
+  { href: '/logout', label: 'Cerrar sesión', roles: ['user', 'admin', 'trabajador'] },
 ]
 
 export default function TopBar() {


### PR DESCRIPTION
## Summary
- add attendance page with role protections and state-based actions
- expose asistencia link for workers and admins

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d0690a78832f9cea23eba788b319